### PR TITLE
Fix incorrect package names for python3-pyquery and qt6-qtdeclaractive

### DIFF
--- a/install-scripts/00-hypr-pkgs.sh
+++ b/install-scripts/00-hypr-pkgs.sh
@@ -32,7 +32,7 @@ hypr_package=(
   polkit-gnome
   python3-requests
   python3-pip
-  python-pyquery
+  python3-pyquery
   qt5ct
   qt6ct
   qt6-qtsvg

--- a/install-scripts/sddm.sh
+++ b/install-scripts/sddm.sh
@@ -5,7 +5,7 @@
 sddm=(
 	sddm
   qt6-qt5compat 
-  qt6-declarative 
+  qt6-qtdeclarative 
   qt6-qtsvg
 )
 


### PR DESCRIPTION
# Pull Request

## Description

Fixed a couple incorrect package names that were generating errors during install:

- python-pyquery -> python3-pyquery
- qt6-declarative -> qt6-qtdeclarative

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Fedora-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
