### PR TITLE
AGSv1 keep as backup, don't uninstall 

### DIFF
--- a/install-scripts/quickshell.sh
+++ b/install-scripts/quickshell.sh
@@ -41,15 +41,7 @@ for pkg in "${quick[@]}"; do
     install_package "$pkg" "$LOG"
 done
 
-# removal of ags
-# Check if the file exists and remove it
-printf "\n%s - removing ${SKY_BLUE}AGS${RESET}  \n" "${NOTE}"
-if [ -f "/usr/local/bin/ags" ]; then
-    sudo rm -r /usr/local/bin/ags
-fi
-
-if [ -d "/usr/local/share/com.github.Aylur.ags" ]; then
-    sudo rm -rf /usr/local/share/com.github.Aylur.ags
-fi
+# NOTE: AGS is no longer removed to allow both AGS and Quickshell to coexist
+# The Hyprland-Dots OverviewToggle.sh script handles fallback between them
 
 printf "\n%.0s" {1..1}


### PR DESCRIPTION

# Pull Request

## Description
Remove AGS deletion from quickshell.sh installation script. Both AGS and Quickshell can now be installed simultaneously.

The Hyprland-Dots OverviewToggle.sh script (SUPER+A) handles automatic fallback between Quickshell and AGS, trying Quickshell first and falling back to AGS if needed.

This resolves issues where users had to choose between the two tools, even when both might be needed for redundancy during periods of instability in either project.


## Type of change

Please put an `x` in the boxes that apply:


- [X] **New feature** (non-breaking change which adds functionality)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

 