### PR TITLE
Fedora(dev): AGS v1.9.0 fix — add env wrapper and harden ESM patching…

### DIFF
--- a/install-scripts/ags.sh
+++ b/install-scripts/ags.sh
@@ -66,9 +66,9 @@ printf "\n%.0s" {1..1}
 printf "${NOTE} Install and Compiling ${SKY_BLUE}Aylur's GTK shell $ags_tag${RESET}..\n"
 
 # Check if directory exists and remove it
-if [ -d "ags" ]; then
+if [ -d "ags_v1.9.0" ]; then
     printf "${NOTE} Removing existing ags directory...\n"
-    rm -rf "ags"
+    rm -rf "ags_v1.9.0"
 fi
 
 printf "\n%.0s" {1..1}
@@ -81,8 +81,85 @@ if git clone --depth=1 https://github.com/JaKooLit/ags_v1.9.0.git; then
     meson setup build
    if sudo meson install -C build 2>&1 | tee -a "$MLOG"; then
     printf "\n${OK} ${YELLOW}Aylur's GTK shell $ags_tag${RESET} installed successfully.\n" 2>&1 | tee -a "$MLOG"
+
+    # Patch installed AGS launchers to ensure GI typelibs in /usr/local/lib are discoverable in GJS ESM
+    printf "${NOTE} Applying AGS launcher patch for GI typelibs search path...\n"
+
+    patch_ags_launcher() {
+      local target="$1"
+      if ! sudo test -f "$target"; then
+        return 1
+      fi
+
+      # 1) Remove deprecated GIR Repository path tweaks and GIRepository import (harmless if absent)
+      sudo sed -i \
+        -e '/Repository\.prepend_search_path/d' \
+        -e '/Repository\.prepend_library_path/d' \
+        -e '/gi:\/\/GIRepository/d' \
+        "$target"
+
+      # 2) Ensure GLib import exists (insert after first import line, or at top if none)
+      if ! sudo grep -q '^import GLib from "gi://GLib";' "$target"; then
+        TMPF=$(sudo mktemp)
+        sudo awk 'BEGIN{added=0} {
+          if (!added && $0 ~ /^import /) { print; print "import GLib from \"gi://GLib\";"; added=1; next }
+          print
+        } END { if (!added) print "import GLib from \"gi://GLib\";" }' "$target" | sudo tee "$TMPF" >/dev/null
+        sudo mv "$TMPF" "$target"
+      fi
+
+      # 3) Inject GI_TYPELIB_PATH export right after the GLib import (once)
+      if ! sudo grep -q 'GLib.setenv("GI_TYPELIB_PATH"' "$target"; then
+        TMPF=$(sudo mktemp)
+        sudo awk '{print} $0 ~ /^import GLib from "gi:\/\/GLib";$/ {print "const __old = GLib.getenv(\"GI_TYPELIB_PATH\");"; print "GLib.setenv(\"GI_TYPELIB_PATH\", \"/usr/local/lib64/girepository-1.0:/usr/local/lib/girepository-1.0\" + (__old ? \":\" + __old : \"\"), true);"; print "const __oldld = GLib.getenv(\"LD_LIBRARY_PATH\");"; print "GLib.setenv(\"LD_LIBRARY_PATH\", \"/usr/local/lib64:/usr/local/lib\" + (__oldld ? \":\" + __oldld : \"\"), true);"}' "$target" | sudo tee "$TMPF" >/dev/null
+        sudo mv "$TMPF" "$target"
+      fi
+
+      # 4) Ensure LD_LIBRARY_PATH export exists even if GI_TYPELIB_PATH was already present
+      if ! sudo grep -q 'GLib.setenv("LD_LIBRARY_PATH"' "$target"; then
+        TMPF=$(sudo mktemp)
+        sudo awk '{print} $0 ~ /^import GLib from "gi:\/\/GLib";$/ {print "const __oldld = GLib.getenv(\"LD_LIBRARY_PATH\");"; print "GLib.setenv(\"LD_LIBRARY_PATH\", \"/usr/local/lib64:/usr/local/lib\" + (__oldld ? \":\" + __oldld : \"\"), true);"}' "$target" | sudo tee "$TMPF" >/dev/null
+        sudo mv "$TMPF" "$target"
+      fi
+
+      # Restore executable bit for bin wrappers (mv from mktemp resets mode to 0600)
+      case "$target" in
+        */bin/ags)
+          sudo chmod 0755 "$target" || true
+          ;;
+      esac
+
+      printf "${OK} Patched: %s\n" "$target"
+      return 0
+    }
+
+    # Try common locations
+    for CAND in \
+      "/usr/local/share/com.github.Aylur.ags/com.github.Aylur.ags" \
+      "/usr/share/com.github.Aylur.ags/com.github.Aylur.ags" \
+      "/usr/local/bin/ags" \
+      "/usr/bin/ags"; do
+      patch_ags_launcher "$CAND" || true
+    done
+
+    # Create an env-setting wrapper for AGS to ensure GI typelibs/libs are discoverable
+    printf "${NOTE} Creating env wrapper /usr/local/bin/ags...\n"
+    MAIN_JS="/usr/local/share/com.github.Aylur.ags/com.github.Aylur.ags"
+    if ! sudo test -f "$MAIN_JS"; then
+      MAIN_JS="/usr/share/com.github.Aylur.ags/com.github.Aylur.ags"
+    fi
+    sudo tee /usr/local/bin/ags >/dev/null <<WRAP
+#!/usr/bin/env bash
+set -euo pipefail
+# Ensure GI typelibs and native libs are discoverable before gjs ESM loads
+export GI_TYPELIB_PATH="/usr/local/lib64/girepository-1.0:/usr/local/lib/girepository-1.0:/usr/lib64/girepository-1.0:/usr/lib/girepository-1.0:/usr/local/lib64:/usr/local/lib:/usr/lib64/ags:${GI_TYPELIB_PATH:-}"
+export LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH:-}"
+exec /usr/bin/gjs -m "$MAIN_JS" "$@"
+WRAP
+    sudo chmod 0755 /usr/local/bin/ags
+    printf "${OK} AGS wrapper installed at /usr/local/bin/ags\n"
   else
-    echo -e "\n${ERROR} ${YELLOW}Aylur's GTK shell $ags_tag${RESET} Installation failed\n " 2>&1 | tee -a "$MLOG"
+    echo -e "\n${ERROR} ${YELLOW} Aylur's GTK shell $ags_tag${RESET} Installation failed\n " 2>&1 | tee -a "$MLOG"
    fi
     # Move logs to Install-Logs directory
     mv "$MLOG" ../Install-Logs/ || true


### PR DESCRIPTION
… (base: development)

# Pull Request

## Description

Fedora: patch AGS v1.9.0 launcher(s) for GJS ESM + fix cleanup dir
Context

Fedora exhibits the same AGS v1 issue as Arch: under GJS ESM, GIR.Repository.prepend_* is ineffective and triggers
TypeError (Repository.prepend_search_path is not a function). Typelibs under /usr/local/lib are not found reliably.
Changes

After meson install, patch all common launcher locations:
/usr/local/share/com.github.Aylur.ags/com.github.Aylur.ags
/usr/share/com.github.Aylur.ags/com.github.Aylur.ags
/usr/local/bin/ags
/usr/bin/ags
For each existing target:
Replace import GIR from "gi://GIRepository?version=2.0"; with import GLib from "gi://GLib";
Remove GIR.Repository.prepend_search_path and GIR.Repository.prepend_library_path calls
Inject GLib-based export of GI_TYPELIB_PATH (prepend /usr/local/lib to any existing value)
Correct cleanup step to remove ags_v1.9.0 dir instead of ags.
Why

Ensures AGS v1 runs on Fedora with GJS ESM without GI errors and mirrors the behavior expected in Arch.
Covers multiple installation layouts where the launcher may live in share/ or bin/ paths.
File

install-scripts/ags.sh
Notes

If a target launcher is not present (e.g., different prefix or distro package), patching is skipped per target.

## Type of change

 
- [X] **Bug fix** (non-breaking change which fixes an issue)
-
## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.


## Screenshots

Verifying both work now 

AGS
<img width="1371" height="429" alt="image" src="https://github.com/user-attachments/assets/9c024d4d-649a-46e9-9216-07b5f10c745f" />

QS
<img width="1361" height="400" alt="image" src="https://github.com/user-attachments/assets/fd6e0d68-ab27-4de6-be5f-20a9b884faee" />





