### PR TITLE
Development to main -  Replace COPR for Hyprland 

### DIFF
--- a/install-scripts/copr.sh
+++ b/install-scripts/copr.sh
@@ -9,9 +9,11 @@
 # tofik/nwg-shell - nwg-displays ONLY
 
 # List of COPR repositories to be added and enabled
+# solopasha/hyprland   # No longer getting updated 
+# Replaced with sdegler/hypr-test 11/21/2025
+
 COPR_REPOS=(
   sdegler/hypr-test
-  # solopasha/hyprland   # No longer getting updated 
   erikreider/SwayNotificationCenter
   errornointernet/packages
   tofik/nwg-shell 


### PR DESCRIPTION
# Pull Request

## Description

A recent Hyprland change of `hyprland-qtuils` to `hyprland-guiutils`  required updated packages. 
The `solopasha/hyprland`  COPR we've been using hasn't been updating, and no one seems to have heard from them. 
This causes update failures on Fedora. 

@sdegler  Has  created a COPR to resolve this.  `sdegler/hypr-test`   I have tested it with Fedora 42/43/Rawhide  All worked without issue. 

Created a Post on the discord server on how to change to the new COPR. 

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
 
## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.


## Screenshots
 
<img width="949" height="253" alt="image" src="https://github.com/user-attachments/assets/fe30f1ea-4b9b-421f-9ea7-4e7354203dac" />

<img width="1828" height="306" alt="image" src="https://github.com/user-attachments/assets/be9151aa-e933-4efa-b604-08975d0cf554" />
