### PR TITLE
Rofi-wayland was changed to rofi -- final check scrtipt was still checking for rofi-wayland

### DIFF
--- a/install-scripts/00-hypr-pkgs.sh
+++ b/install-scripts/00-hypr-pkgs.sh
@@ -40,7 +40,7 @@ hypr_package=(
   qt5ct
   qt6ct
   qt6-qtsvg
-  rofi-wayland
+  rofi
   slurp
   swappy
   unzip # required later

--- a/install-scripts/02-Final-Check.sh
+++ b/install-scripts/02-Final-Check.sh
@@ -6,7 +6,7 @@
 packages=(
   cliphist
   kvantum
-  rofi-wayland
+  rofi
   ImageMagick
   SwayNotificationCenter
   swww


### PR DESCRIPTION

# Pull Request

## Description

This final check script still looked for `rofi-wayland` causing error

Also main was updated already to install `rofi` .vs `rofi-wayland`   This updates development to match

 On branch development
 Your branch is up to date with 'origin/development'.

 Changes to be committed:
	modified:   00-hypr-pkgs.sh
	modified:   02-Final-Check.sh

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Fedora-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
 